### PR TITLE
Fix attendee status positioning

### DIFF
--- a/src/app/overview/page.tsx
+++ b/src/app/overview/page.tsx
@@ -343,9 +343,24 @@ function MatchOverviewCard({ match, index, eventId, updatingStatus, onStatusUpda
         <div className="hidden md:grid grid-cols-12 gap-4 items-center">
           {/* Person 1 - Fixed width columns */}
           <div className="col-span-4 flex items-center gap-4">
-            <div className="relative w-16 h-16 rounded-full overflow-hidden bg-gray-700 flex-shrink-0">
-              {/* Status Chip positioned over profile image */}
-              <div className="absolute -top-1 -right-1 z-10">
+            <div className="flex flex-col items-center">
+              <div className="relative w-16 h-16 rounded-full overflow-hidden bg-gray-700 flex-shrink-0">
+                <Image
+                  src={getProfileImage(match.attendee)}
+                  alt={match.attendee}
+                  fill
+                  className="object-cover"
+                  onError={(e) => {
+                    const target = e.target as HTMLImageElement;
+                    target.style.display = 'none';
+                    const parent = target.parentElement;
+                    if (parent) {
+                      parent.innerHTML = `<div class=\"w-full h-full flex items-center justify-center text-white font-bold text-lg\">${getInitials(match.attendee)}</div>`;
+                    }
+                  }}
+                />
+              </div>
+              <div className="mt-2">
                 <StatusChip
                   status={match.attendeeProfile.status || 'Not Arrived'}
                   onStatusChange={(newStatus) => onStatusUpdate(match.attendeeProfile.id, newStatus)}
@@ -355,20 +370,6 @@ function MatchOverviewCard({ match, index, eventId, updatingStatus, onStatusUpda
                   interactive={true}
                 />
               </div>
-              <Image
-                src={getProfileImage(match.attendee)}
-                alt={match.attendee}
-                fill
-                className="object-cover"
-                onError={(e) => {
-                  const target = e.target as HTMLImageElement;
-                  target.style.display = 'none';
-                  const parent = target.parentElement;
-                  if (parent) {
-                    parent.innerHTML = `<div class="w-full h-full flex items-center justify-center text-white font-bold text-lg">${getInitials(match.attendee)}</div>`;
-                  }
-                }}
-              />
             </div>
             <div className="min-w-0 flex-1">
               <h3 className="font-semibold text-white text-base truncate">{match.attendee}</h3>
@@ -382,9 +383,24 @@ function MatchOverviewCard({ match, index, eventId, updatingStatus, onStatusUpda
 
           {/* Person 2 - Fixed width columns */}
           <div className="col-span-4 flex items-center gap-4">
-            <div className="relative w-16 h-16 rounded-full overflow-hidden bg-gray-700 flex-shrink-0">
-              {/* Status Chip positioned over profile image */}
-              <div className="absolute -top-1 -right-1 z-10">
+            <div className="flex flex-col items-center">
+              <div className="relative w-16 h-16 rounded-full overflow-hidden bg-gray-700 flex-shrink-0">
+                <Image
+                  src={getProfileImage(match.match)}
+                  alt={match.match}
+                  fill
+                  className="object-cover"
+                  onError={(e) => {
+                    const target = e.target as HTMLImageElement;
+                    target.style.display = 'none';
+                    const parent = target.parentElement;
+                    if (parent) {
+                      parent.innerHTML = `<div class=\"w-full h-full flex items-center justify-center text-white font-bold text-lg\">${getInitials(match.match)}</div>`;
+                    }
+                  }}
+                />
+              </div>
+              <div className="mt-2">
                 <StatusChip
                   status={match.matchProfile.status || 'Not Arrived'}
                   onStatusChange={(newStatus) => onStatusUpdate(match.matchProfile.id, newStatus)}
@@ -394,20 +410,6 @@ function MatchOverviewCard({ match, index, eventId, updatingStatus, onStatusUpda
                   interactive={true}
                 />
               </div>
-              <Image
-                src={getProfileImage(match.match)}
-                alt={match.match}
-                fill
-                className="object-cover"
-                onError={(e) => {
-                  const target = e.target as HTMLImageElement;
-                  target.style.display = 'none';
-                  const parent = target.parentElement;
-                  if (parent) {
-                    parent.innerHTML = `<div class="w-full h-full flex items-center justify-center text-white font-bold text-lg">${getInitials(match.match)}</div>`;
-                  }
-                }}
-              />
             </div>
             <div className="min-w-0 flex-1">
               <h3 className="font-semibold text-white text-base truncate">{match.match}</h3>

--- a/src/components/AttendeeCard.tsx
+++ b/src/components/AttendeeCard.tsx
@@ -48,7 +48,7 @@ export default function AttendeeCard({
   if (compact) {
     return (
       <div className="flex items-center gap-3 p-3 bg-white/5 backdrop-blur-xl border border-white/10 rounded-xl hover:bg-white/8 transition-all duration-300">
-        <div className="relative">
+        <div className="flex flex-col items-center relative">
           <div className="relative w-12 h-12 rounded-full overflow-hidden bg-gradient-to-br from-purple-500 to-blue-500 flex-shrink-0">
             <Image
               src={getProfileImage(profile.name)}
@@ -60,12 +60,12 @@ export default function AttendeeCard({
                 target.style.display = 'none';
                 const parent = target.parentElement;
                 if (parent) {
-                  parent.innerHTML = `<div class="w-full h-full flex items-center justify-center text-white font-bold text-sm">${getInitials(profile.name)}</div>`;
+                  parent.innerHTML = `<div class=\"w-full h-full flex items-center justify-center text-white font-bold text-sm\">${getInitials(profile.name)}</div>`;
                 }
               }}
             />
           </div>
-          <div className="absolute -bottom-1 -right-1">
+          <div className="mt-1">
             <StatusChip
               status={currentStatus}
               onStatusChange={onStatusUpdate ? handleStatusChange : undefined}
@@ -95,8 +95,8 @@ export default function AttendeeCard({
   return (
     <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-xl p-6 hover:bg-white/8 transition-all duration-300 group">
       <div className="flex items-start gap-4">
-        {/* Profile Image with Status Overlay */}
-        <div className="relative">
+        {/* Profile Image with Status below */}
+        <div className="flex flex-col items-center relative">
           <div className="relative w-16 h-16 rounded-xl overflow-hidden bg-gradient-to-br from-purple-500 to-blue-500 flex-shrink-0 shadow-lg">
             <Image
               src={getProfileImage(profile.name)}
@@ -114,8 +114,7 @@ export default function AttendeeCard({
             />
           </div>
           
-          {/* Status Chip positioned adjacent to image */}
-          <div className="absolute -top-2 -right-2">
+          <div className="mt-2">
             <StatusChip
               status={currentStatus}
               onStatusChange={onStatusUpdate ? handleStatusChange : undefined}


### PR DESCRIPTION
## Summary
- move StatusChip under profile image in attendee cards
- reposition status chip below images on the overview page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e82d475608321b0e16f0581ef730c